### PR TITLE
Add support for feed deltas

### DIFF
--- a/src/crawler/http_crawler.py
+++ b/src/crawler/http_crawler.py
@@ -238,6 +238,8 @@ class CrawlerScheduler(AbstractCrawler):
             headers['If-Modified-Since'] = feed['last_modified']
         if feed.get('etag') and 'jarr' not in feed['etag']:
             headers['If-None-Match'] = feed['etag']
+        if 'If-Modified-Since' in headers or 'If-None-Match' in headers:
+            headers['A-IM'] = 'feed'
         logger.debug('%r %r - calculated headers %r',
                      feed['id'], feed['title'], headers)
         return headers


### PR DESCRIPTION
Add `A-IM: feed` header when either `If-Modified-Since` or `If-None-Match` is also set. Instructs compatible servers to only return new or modified entries in a [feed delta update](https://www.slightfuture.com/webdev/feed-caching) rather than the whole feed.