### PR TITLE
Maintenance on url handling

### DIFF
--- a/jarr/controllers/article.py
+++ b/jarr/controllers/article.py
@@ -8,6 +8,7 @@ from werkzeug.exceptions import Forbidden, Unauthorized
 from jarr.bootstrap import session
 from jarr.controllers import CategoryController, FeedController
 from jarr.lib.clustering_af.postgres_casting import to_vector
+from jarr.lib.url_cleaners import remove_utm_tags
 from jarr.lib.utils import utc_now
 from jarr.models import Article, User
 
@@ -76,7 +77,8 @@ class ArticleController(AbstractController):
             raise Forbidden("no right on feed %r" % feed.id)
         attrs['user_id'], attrs['category_id'] = feed.user_id, feed.category_id
         attrs['vector'] = to_vector(attrs)
-        attrs['link_hash'] = sha1(attrs['link'].encode('utf8')).digest()
+        attrs['link_hash'] = (sha1(remove_utm_tags(attrs['link']
+                                   ).encode('utf8')).digest())
         article = super().create(**attrs)
         return article
 

--- a/jarr/controllers/article.py
+++ b/jarr/controllers/article.py
@@ -77,8 +77,11 @@ class ArticleController(AbstractController):
             raise Forbidden("no right on feed %r" % feed.id)
         attrs['user_id'], attrs['category_id'] = feed.user_id, feed.category_id
         attrs['vector'] = to_vector(attrs)
-        attrs['link_hash'] = (sha1(remove_utm_tags(attrs['link']
-                                   ).encode('utf8')).digest())
+        if 'link' in attrs:
+            attrs['link_hash'] = (sha1(remove_utm_tags(attrs['link']
+                                       ).encode('utf8')).digest())
+            if 'content' in attrs:
+                attrs['content'] = clean_urls(attrs['content'], attrs['link'])
         article = super().create(**attrs)
         return article
 

--- a/jarr/controllers/article.py
+++ b/jarr/controllers/article.py
@@ -7,7 +7,7 @@ from werkzeug.exceptions import Forbidden, Unauthorized
 from jarr.bootstrap import session
 from jarr.controllers import CategoryController, FeedController
 from jarr.lib.clustering_af.postgres_casting import to_vector
-from jarr.lib.utils import utc_now
+from jarr.lib.utils import digest, utc_now
 from jarr.models import Article, User
 
 from .abstract import AbstractController
@@ -75,6 +75,9 @@ class ArticleController(AbstractController):
             raise Forbidden("no right on feed %r" % feed.id)
         attrs['user_id'], attrs['category_id'] = feed.user_id, feed.category_id
         attrs['vector'] = to_vector(attrs)
+        if not attrs.get('link_hash') and attrs.get('link'):
+            attrs['link_hash'] = digest(attrs['link'],
+                                        algo='sha1', out='bytes')
         return super().create(**attrs)
 
     def update(self, filters, attrs, return_objs=False, commit=True):

--- a/jarr/controllers/article.py
+++ b/jarr/controllers/article.py
@@ -7,8 +7,7 @@ from werkzeug.exceptions import Forbidden, Unauthorized
 from jarr.bootstrap import session
 from jarr.controllers import CategoryController, FeedController
 from jarr.lib.clustering_af.postgres_casting import to_vector
-from jarr.lib.url_cleaners import clean_urls, remove_utm_tags
-from jarr.lib.utils import digest, utc_now
+from jarr.lib.utils import utc_now
 from jarr.models import Article, User
 
 from .abstract import AbstractController
@@ -76,13 +75,7 @@ class ArticleController(AbstractController):
             raise Forbidden("no right on feed %r" % feed.id)
         attrs['user_id'], attrs['category_id'] = feed.user_id, feed.category_id
         attrs['vector'] = to_vector(attrs)
-        if attrs.get('link'):
-            attrs['link_hash'] = digest(remove_utm_tags(attrs['link']),
-                                        algo='sha1', out='bytes')
-            if attrs.get('content'):
-                attrs['content'] = clean_urls(attrs['content'], attrs['link'])
-        article = super().create(**attrs)
-        return article
+        return super().create(**attrs)
 
     def update(self, filters, attrs, return_objs=False, commit=True):
         user_id = attrs.get('user_id', self.user_id)

--- a/jarr/controllers/article.py
+++ b/jarr/controllers/article.py
@@ -1,6 +1,5 @@
 import logging
 from datetime import timedelta
-from hashlib import sha1
 
 from sqlalchemy import func
 from werkzeug.exceptions import Forbidden, Unauthorized
@@ -8,8 +7,8 @@ from werkzeug.exceptions import Forbidden, Unauthorized
 from jarr.bootstrap import session
 from jarr.controllers import CategoryController, FeedController
 from jarr.lib.clustering_af.postgres_casting import to_vector
-from jarr.lib.url_cleaners import remove_utm_tags
-from jarr.lib.utils import utc_now
+from jarr.lib.url_cleaners import clean_urls, remove_utm_tags
+from jarr.lib.utils import utc_now, to_hash
 from jarr.models import Article, User
 
 from .abstract import AbstractController
@@ -78,8 +77,7 @@ class ArticleController(AbstractController):
         attrs['user_id'], attrs['category_id'] = feed.user_id, feed.category_id
         attrs['vector'] = to_vector(attrs)
         if 'link' in attrs:
-            attrs['link_hash'] = (sha1(remove_utm_tags(attrs['link']
-                                       ).encode('utf8')).digest())
+            attrs['link_hash'] = to_hash(remove_utm_tags(attrs['link']), 'sha')
             if 'content' in attrs:
                 attrs['content'] = clean_urls(attrs['content'], attrs['link'])
         article = super().create(**attrs)

--- a/jarr/controllers/article.py
+++ b/jarr/controllers/article.py
@@ -8,7 +8,7 @@ from jarr.bootstrap import session
 from jarr.controllers import CategoryController, FeedController
 from jarr.lib.clustering_af.postgres_casting import to_vector
 from jarr.lib.url_cleaners import clean_urls, remove_utm_tags
-from jarr.lib.utils import utc_now, to_hash
+from jarr.lib.utils import digest, utc_now
 from jarr.models import Article, User
 
 from .abstract import AbstractController
@@ -77,7 +77,8 @@ class ArticleController(AbstractController):
         attrs['user_id'], attrs['category_id'] = feed.user_id, feed.category_id
         attrs['vector'] = to_vector(attrs)
         if attrs.get('link'):
-            attrs['link_hash'] = to_hash(remove_utm_tags(attrs['link']), 'sha')
+            attrs['link_hash'] = digest(remove_utm_tags(attrs['link']),
+                                        algo='sha1', out='bytes')
             if attrs.get('content'):
                 attrs['content'] = clean_urls(attrs['content'], attrs['link'])
         article = super().create(**attrs)

--- a/jarr/controllers/article.py
+++ b/jarr/controllers/article.py
@@ -76,9 +76,9 @@ class ArticleController(AbstractController):
             raise Forbidden("no right on feed %r" % feed.id)
         attrs['user_id'], attrs['category_id'] = feed.user_id, feed.category_id
         attrs['vector'] = to_vector(attrs)
-        if 'link' in attrs:
+        if attrs.get('link'):
             attrs['link_hash'] = to_hash(remove_utm_tags(attrs['link']), 'sha')
-            if 'content' in attrs:
+            if attrs.get('content'):
                 attrs['content'] = clean_urls(attrs['content'], attrs['link'])
         article = super().create(**attrs)
         return article

--- a/jarr/crawler/article_builders/abstract.py
+++ b/jarr/crawler/article_builders/abstract.py
@@ -69,7 +69,7 @@ class AbstractArticleBuilder:
         raise NotImplementedError()
 
     @staticmethod
-    def to_link_hash(link):
+    def to_hash(link):
         return digest(remove_utm_tags(link), algo='sha1', out='bytes')
 
     def construct(self, entry):

--- a/jarr/crawler/article_builders/abstract.py
+++ b/jarr/crawler/article_builders/abstract.py
@@ -88,7 +88,7 @@ class AbstractArticleBuilder:
         self.article['lang'] = self.extract_lang(entry)
         self.article['comments'] = self.extract_comments(entry)
         if self.article.get('link'):
-            attrs['link_hash'] = self.to_hash(self.article['link'])
+            self.article['link_hash'] = self.to_hash(self.article['link'])
             if self.article.get('content'):
                 self.article['content'] = clean_urls(self.article['content'],
                                                      self.article['link'])

--- a/jarr/crawler/article_builders/abstract.py
+++ b/jarr/crawler/article_builders/abstract.py
@@ -120,6 +120,7 @@ class AbstractArticleBuilder:
 
         if self.article['link'] != head.url:
             self.article['link'] = head.url  # fix link in case of redirect
+            # removing utm_tags from link_hash, to allow clustering despite em
             clean_link = remove_utm_tags(self.article['link'])
             if clean_link != self.article['link']:
                 clean_head = self._head(clean_link)

--- a/jarr/crawler/article_builders/abstract.py
+++ b/jarr/crawler/article_builders/abstract.py
@@ -7,7 +7,8 @@ from jarr.bootstrap import conf
 from jarr.lib.content_generator import is_embedded_link
 from jarr.lib.enums import ArticleType
 from jarr.lib.filter import FiltersAction, process_filters
-from jarr.lib.utils import utc_now
+from jarr.lib.url_cleaners import clean_urls, remove_utm_tags
+from jarr.lib.utils import digest, utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +68,10 @@ class AbstractArticleBuilder:
     def extract_comments(entry):
         raise NotImplementedError()
 
+    @staticmethod
+    def to_link_hash(link):
+        return digest(remove_utm_tags(link), algo='sha1', out='bytes')
+
     def construct(self, entry):
         self.article = self.template_article()
         if not entry:
@@ -82,6 +87,11 @@ class AbstractArticleBuilder:
         self.article['content'] = self.extract_content(entry)
         self.article['lang'] = self.extract_lang(entry)
         self.article['comments'] = self.extract_comments(entry)
+        if self.article.get('link'):
+            attrs['link_hash'] = self.to_hash(self.article['link'])
+            if self.article.get('content'):
+                self.article['content'] = clean_urls(self.article['content'],
+                                                     self.article['link'])
 
     @classmethod
     def _head(cls, url, reraise=False):
@@ -108,7 +118,13 @@ class AbstractArticleBuilder:
         if not head:
             return self.article
 
-        self.article['link'] = head.url  # correcting link in case of redirect
+        if self.article['link'] != head.url:
+            self.article['link'] = head.url  # fix link in case of redirect
+            clean_link = remove_utm_tags(self.article['link'])
+            if clean_link != self.article['link']:
+                clean_head = self._head(clean_link)
+                if clean_head:
+                    self.article['link_hash'] = self.to_hash(clean_head.url)
         content_type = str(head.headers.get('Content-Type')) or ''
         if content_type.startswith('image/'):
             self.article['article_type'] = ArticleType.image

--- a/jarr/crawler/lib/headers_handling.py
+++ b/jarr/crawler/lib/headers_handling.py
@@ -6,7 +6,7 @@ import dateutil.parser
 
 from jarr.bootstrap import conf
 from jarr.lib.const import FEED_ACCEPT_HEADERS
-from jarr.lib.utils import rfc_1123_utc, to_hash, utc_now
+from jarr.lib.utils import digest, rfc_1123_utc, utc_now
 
 logger = logging.getLogger(__name__)
 MAX_AGE_RE = re.compile('max-age=([0-9]+)')

--- a/jarr/crawler/lib/headers_handling.py
+++ b/jarr/crawler/lib/headers_handling.py
@@ -46,7 +46,7 @@ def extract_feed_info(headers, text=None):
     feed_info = {'etag': headers.get('etag', ''),
                  'last_modified': headers.get('last-modified', rfc_1123_utc())}
     if text and not feed_info['etag']:
-        feed_info['etag'] = 'jarr/"%s"' % to_hash(text)
+        feed_info['etag'] = 'jarr/"%s"' % digest(text)
 
     _extract_max_age(headers, feed_info)
     if 'expires' not in feed_info:

--- a/jarr/crawler/requests_utils.py
+++ b/jarr/crawler/requests_utils.py
@@ -1,7 +1,6 @@
 import logging
 
-
-from jarr.lib.utils import to_hash
+from jarr.lib.utils import digest
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +17,7 @@ def response_etag_match(feed, resp):
 
 
 def response_calculated_etag_match(feed, resp):
-    if ('jarr/"%s"' % to_hash(resp.text)) == feed.etag:
+    if ('jarr/"%s"' % digest(resp.text)) == feed.etag:
         logger.info("%r: calculated hash matches (%d)",
                     feed, resp.status_code)
         return True

--- a/jarr/lib/url_cleaners.py
+++ b/jarr/lib/url_cleaners.py
@@ -1,7 +1,8 @@
 import logging
-import goose3
-from urllib.parse import ParseResult, unquote, urlparse, urlunparse
+from urllib.parse import (ParseResult, parse_qs, unquote, urlencode, urlparse,
+                          urlunparse)
 
+import goose3
 from bs4 import BeautifulSoup
 
 from jarr.bootstrap import conf, is_secure_served
@@ -11,16 +12,18 @@ logger = logging.getLogger(__name__)
 
 
 def __fix_addr(to_fix, reference, scheme=None):
+    "will try to repare a broken link with data from another"
     scheme = scheme or to_fix.scheme or reference.scheme
     netloc = to_fix.netloc
     if reference:
         netloc = to_fix.netloc or reference.netloc
     return urlunparse(ParseResult(scheme=scheme, netloc=netloc,
-                      path=to_fix.path, query=to_fix.query,
-                      params=to_fix.params, fragment=to_fix.fragment))
+                                  path=to_fix.path, query=to_fix.query,
+                                  params=to_fix.params,
+                                  fragment=to_fix.fragment))
 
 
-def _handle_img(img, parsed_article_url, fix_readability):
+def _handle_img(img, parsed_article_url):
     """
     Will fix images url.
 
@@ -28,11 +31,6 @@ def _handle_img(img, parsed_article_url, fix_readability):
     """
     if 'src' not in img.attrs:
         return
-    # bug reported to readability, fixing it here for now
-    if fix_readability:
-        splited_src = unquote(img.attrs['src']).split(', ')
-        if len(splited_src) > 1:
-            img.attrs['src'] = splited_src[0].split()[0]
     if is_secure_served() and 'srcset' in img.attrs \
             and not img.attrs['srcset'].startswith("https"):
         # removing unsecure active content when serving over https
@@ -69,7 +67,7 @@ def _handle_iframe(iframe):
         iframe.attrs['src'] = __fix_addr(iframe_src, None, 'https')
 
 
-def clean_urls(article_content, article_link, fix_readability=False):
+def clean_urls(article_content, article_link):
     parsed_article_url = urlparse(article_link)
     parsed_content = BeautifulSoup(article_content, 'html.parser')
 
@@ -82,7 +80,20 @@ def clean_urls(article_content, article_link, fix_readability=False):
         if elem.name == 'a':
             _handle_link(elem, parsed_article_url)
         elif elem.name == 'img':
-            _handle_img(elem, parsed_article_url, fix_readability)
+            _handle_img(elem, parsed_article_url)
         elif elem.name == 'iframe':
             _handle_iframe(elem)
     return str(parsed_content)
+
+
+def remove_utm_tags(link):
+    parsed = urlparse(link)
+    if 'utm_' not in parsed.query:
+        return link
+    query = {key: value for key, value in parse_qs(parsed.query).items()
+             if not key.lower().startswith('utm_')}
+    return urlunparse(ParseResult(scheme=parsed.scheme, netloc=parsed.netloc,
+                                  path=parsed.path,
+                                  query=urlencode(query, doseq=True),
+                                  params=parsed.params,
+                                  fragment=parsed.fragment))

--- a/jarr/lib/url_cleaners.py
+++ b/jarr/lib/url_cleaners.py
@@ -1,11 +1,9 @@
 import logging
-from urllib.parse import (ParseResult, parse_qs, unquote, urlencode, urlparse,
-                          urlunparse)
+from urllib.parse import ParseResult, parse_qs, urlencode, urlparse, urlunparse
 
-import goose3
 from bs4 import BeautifulSoup
 
-from jarr.bootstrap import conf, is_secure_served
+from jarr.bootstrap import is_secure_served
 
 HTTPS_IFRAME_DOMAINS = ('vimeo.com', 'youtube.com', 'youtu.be')
 logger = logging.getLogger(__name__)

--- a/jarr/lib/utils.py
+++ b/jarr/lib/utils.py
@@ -4,7 +4,7 @@ import types
 import urllib
 from datetime import datetime, timezone
 from enum import Enum
-from hashlib import md5
+from hashlib import md5, sha1
 
 import requests
 
@@ -59,9 +59,10 @@ def rebuild_url(url, base_split):
     return urllib.parse.urlunsplit(new_split)
 
 
-def to_hash(text):
-    return md5(text.encode('utf8') if hasattr(text, 'encode') else text)\
-            .hexdigest()
+def to_hash(text, alg='md5', encoding='utf8'):
+    method = md5 if alg == 'md5' else sha1
+    text = text.encode(encoding) if hasattr(text, 'encode') else text
+    return method(text).hexdigest()
 
 
 def jarr_get(url, timeout=None, user_agent=None, headers=None, **kwargs):

--- a/jarr/lib/utils.py
+++ b/jarr/lib/utils.py
@@ -59,10 +59,10 @@ def rebuild_url(url, base_split):
     return urllib.parse.urlunsplit(new_split)
 
 
-def to_hash(text, alg='md5', encoding='utf8'):
-    method = md5 if alg == 'md5' else sha1
+def digest(text, algo='md5', out='str', encoding='utf8'):
+    method = md5 if algo == 'md5' else sha1
     text = text.encode(encoding) if hasattr(text, 'encode') else text
-    return method(text).hexdigest()
+    return getattr(method(text), 'hexdigest' if out == 'str' else 'digest')()
 
 
 def jarr_get(url, timeout=None, user_agent=None, headers=None, **kwargs):

--- a/jarr/models/user.py
+++ b/jarr/models/user.py
@@ -18,7 +18,6 @@ class User(Base):
     email = Column(String(254))
     date_created = Column(UTCDateTime, default=utc_now)
     last_connection = Column(UTCDateTime, default=utc_now)
-    readability_key = Column(String, default='')
     renew_password_token = Column(String, default='')
 
     timezone = Column(String, default=conf.timezone)

--- a/migrations/versions/20201108_drop_readability_leftovers.py
+++ b/migrations/versions/20201108_drop_readability_leftovers.py
@@ -5,15 +5,16 @@ Revises: f5978c8a8740
 Create Date: 2020-11-08 20:28:31.145702
 
 """
+import logging
 
-# revision identifiers, used by Alembic.
+import sqlalchemy as sa
+from alembic import op
+
+logger = logging.getLogger(__name__)
 revision = 'f4543055e780'
 down_revision = 'f5978c8a8740'
 branch_labels = None
 depends_on = None
-
-from alembic import op
-import sqlalchemy as sa
 
 
 def upgrade():

--- a/migrations/versions/20201108_drop_readability_leftovers.py
+++ b/migrations/versions/20201108_drop_readability_leftovers.py
@@ -1,0 +1,26 @@
+"""Dropping old integration with readability left overs
+
+Revision ID: f4543055e780
+Revises: f5978c8a8740
+Create Date: 2020-11-08 20:28:31.145702
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'f4543055e780'
+down_revision = 'f5978c8a8740'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    logger.info('dropping readability_key column from user')
+    op.drop_column('user', 'readability_key')
+
+
+def downgrade():
+    op.add_column('user', sa.Column('readability_key',
+                                    sa.String(), nullable=True))

--- a/tests/libs/article_utils_test.py
+++ b/tests/libs/article_utils_test.py
@@ -2,7 +2,7 @@ import unittest
 
 from mock import patch
 
-from jarr.lib.article_cleaner import clean_urls
+from jarr.lib.url_cleaners import clean_urls
 
 SAMPLE = """<a href="link_to_correct.html">
 <img src="http://is_ok.com/image"/>
@@ -20,7 +20,7 @@ class ArticleCleanerTest(unittest.TestCase):
         self.sample = SAMPLE.split('\n')
         self.url = 'https://test.te'
 
-    @patch('jarr.lib.article_cleaner.is_secure_served')
+    @patch('jarr.lib.url_cleaners.is_secure_served')
     def test_clean_clear(self, is_secure_served):
         is_secure_served.return_value = False
         result = clean_urls(SAMPLE, self.url).split('\n')
@@ -33,7 +33,7 @@ class ArticleCleanerTest(unittest.TestCase):
         self.assertEqual(self.sample[6], result[6])  # unchanged
         self.assertEqual('<img src="%s/relative.img"/>' % self.url, result[7])
 
-    @patch('jarr.lib.article_cleaner.is_secure_served')
+    @patch('jarr.lib.url_cleaners.is_secure_served')
     def test_clean_https(self, is_secure_served):
         is_secure_served.return_value = True
         result = clean_urls(SAMPLE, self.url).split('\n')
@@ -48,33 +48,4 @@ class ArticleCleanerTest(unittest.TestCase):
         self.assertEqual(
                 '<img src="http://abs.ol/ute/buggy.img%2C%20otherbuggy.img"/>',
                 result[6])
-        self.assertEqual('<img src="%s/relative.img"/>' % self.url, result[7])
-
-    @patch('jarr.lib.article_cleaner.is_secure_served')
-    def test_clean_clear_fix_readability(self, is_secure_served):
-        is_secure_served.return_value = False
-        result = clean_urls(SAMPLE, self.url, True).split('\n')
-        self.assertEqual('<a href="https://test.te/link_to_correct.html">',
-                         result[0])
-        self.assertEqual(self.sample[1], result[1])  # unchanged
-        self.assertEqual(self.sample[2], result[2])  # unchanged
-        self.assertEqual(self.sample[3], result[3])  # unchanged
-        self.assertEqual(self.sample[4], result[4])  # unchanged
-        self.assertEqual('<img src="http://abs.ol/ute/buggy.img"'
-                         ' srcset="garbage"/>', result[6])
-        self.assertEqual('<img src="%s/relative.img"/>' % self.url, result[7])
-
-    @patch('jarr.lib.article_cleaner.is_secure_served')
-    def test_clean_https_fix_readability(self, is_secure_served):
-        is_secure_served.return_value = True
-        result = clean_urls(SAMPLE, self.url, True).split('\n')
-        self.assertEqual('<a href="https://test.te/link_to_correct.html">',
-                         result[0])
-        self.assertEqual(self.sample[1], result[1])  # unchanged
-        self.assertEqual(self.sample[2], result[2])  # unchanged
-        self.assertEqual(self.sample[3], result[3])  # unchanged
-        self.assertEqual(
-                '<iframe src="https://youtube.com/an_unsecure_video">',
-                result[4])
-        self.assertEqual('<img src="http://abs.ol/ute/buggy.img"/>', result[6])
         self.assertEqual('<img src="%s/relative.img"/>' % self.url, result[7])


### PR DESCRIPTION
* removing utm_tags from link_hash, allowing to cluster on links which only difference is utm tags 
* removing dead code around readability
* reinstating `clean_urls` method that were lost in migration