### PR TITLE
Enhancing processed content and typed article handling in jsclient

### DIFF
--- a/jarr/api/cluster.py
+++ b/jarr/api/cluster.py
@@ -30,6 +30,7 @@ article_model = cluster_ns.model('Article', {
 content_model = cluster_ns.model('ProcessedContent', {
     'type': fields.String(required=True),
     'link': fields.String(required=True),
+    'title': fields.String(skip_none=True),
     'content': fields.String(skip_none=True),
     'comments': fields.String(skip_none=True)})
 model = cluster_ns.model('Cluster', {

--- a/jarr/lib/content_generator.py
+++ b/jarr/lib/content_generator.py
@@ -107,6 +107,7 @@ class TruncatedContentGenerator(ContentGenerator):
         try:
             content['content'] = self._from_goose_to_html()
             content['link'] = self._page.final_url
+            content['title'] = self._page.title
         except Exception:
             logger.exception("Could not rebuild parsed content for %r",
                              self.article)

--- a/jsclient/src/features/clusterlist/components/Article.js
+++ b/jsclient/src/features/clusterlist/components/Article.js
@@ -1,14 +1,26 @@
 import React from "react";
 import PropTypes from "prop-types";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
+import { useTheme } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import Link from "@material-ui/core/Link";
 import Divider from "@material-ui/core/Divider";
 
 import makeStyles from "./style";
 
-function Article({ article, hidden }) {
+function Article({ article, forceShowTitle, hidden }) {
   const classes = makeStyles();
-  let comments;
+  const theme = useTheme();
+  const splitedMode = useMediaQuery(theme.breakpoints.up("md"));
+  let title, comments;
+  if(forceShowTitle || splitedMode) {
+      title = (
+        <>
+          <Typography variant="h6">{article.title}</Typography>
+          <Divider />
+        </>
+      );
+  };
   if (article.comments) {
     comments = (<p><span>Comments</span>
                   <Link color="secondary" target="_blank"
@@ -18,8 +30,7 @@ function Article({ article, hidden }) {
   }
   return (
     <div hidden={hidden} className={classes.article}>
-      <Typography variant="h6">{article.title}</Typography>
-      <Divider />
+      {title}
       <p>
         <span>Link</span>
         <Link color="secondary" target="_blank"
@@ -45,7 +56,12 @@ Article.propTypes = {
     content: PropTypes.string.isRequired,
     comments: PropTypes.string,
   }),
-  hidden: PropTypes.bool.isRequired,
+  hidden: PropTypes.bool,
+  forceShowTitle: PropTypes.bool,
+};
+Article.defaultProps = {
+  hidden: false,
+  forceShowTitle: false
 };
 
 export default Article;

--- a/jsclient/src/features/clusterlist/components/Article.js
+++ b/jsclient/src/features/clusterlist/components/Article.js
@@ -14,12 +14,12 @@ function Article({ article, forceShowTitle, hidden }) {
   const splitedMode = useMediaQuery(theme.breakpoints.up("md"));
   let title, comments;
   if(forceShowTitle || splitedMode) {
-      title = (
-        <>
-          <Typography variant="h6">{article.title}</Typography>
-          <Divider />
-        </>
-      );
+    title = (
+      <>
+        <Typography variant="h6">{article.title}</Typography>
+        <Divider />
+      </>
+    );
   };
   if (article.comments) {
     comments = (<p><span>Comments</span>

--- a/jsclient/src/features/clusterlist/components/Article.js
+++ b/jsclient/src/features/clusterlist/components/Article.js
@@ -18,6 +18,8 @@ function Article({ article, hidden }) {
   }
   return (
     <div hidden={hidden} className={classes.article}>
+      <Typography variant="h6">{article.title}</Typography>
+      <Divider />
       <p>
         <span>Link</span>
         <Link color="secondary" target="_blank"
@@ -39,6 +41,7 @@ function Article({ article, hidden }) {
 Article.propTypes = {
   article: PropTypes.shape({
     link: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
     content: PropTypes.string.isRequired,
     comments: PropTypes.string,
   }),

--- a/jsclient/src/features/clusterlist/components/Articles.js
+++ b/jsclient/src/features/clusterlist/components/Articles.js
@@ -29,7 +29,7 @@ function Articles({ articles, icons, contents }) {
   const classes = makeStyles();
   const hasProcessedContent = !!contents && contents.length > 0;
   const allArticlesAreTyped = articles.reduce(
-      (allTyped, art) => !!(allTyped && articleTypes.includes(art["article_type"])), true);
+    (allTyped, art) => !!(allTyped && articleTypes.includes(art["article_type"])), true);
   // if no content, and no special type, returning simple article
   if (articles.length === 1 && !allArticlesAreTyped && !hasProcessedContent) {
     return <Article article={articles[0]} />;

--- a/jsclient/src/features/clusterlist/components/Articles.js
+++ b/jsclient/src/features/clusterlist/components/Articles.js
@@ -36,8 +36,8 @@ function Articles({ articles, icons, contents }) {
 
   // if no content, and no special type, returning simple article
   if (articles.length === 1
-      && !articleTypes.includes(articles[0].article_type) && !contents) {
-    return <Article article={articles[0]} hidden={false} />;
+      && (!articleTypes.includes(articles[0].article_type) || !contents)) {
+    return <Article article={articles[0]} />;
   }
   if (!!contents && contents.length !== 0) {
     contents.forEach((content) => {
@@ -102,6 +102,7 @@ function Articles({ articles, icons, contents }) {
         article={article}
         aria-labelledby={`t-${index}`}
         index={index}
+        forceShowTitle={true}
         hidden={index !== currentIndex}
       />
     );

--- a/jsclient/src/features/clusterlist/components/Articles.js
+++ b/jsclient/src/features/clusterlist/components/Articles.js
@@ -73,7 +73,7 @@ function Articles({ articles, icons, contents }) {
     }
     if (typedArticles.length !== 0) {
       tabs.push(
-        <Tab key={`t-${index}`} value={index}
+        <Tab key={`ta-${type}`} value={index}
              icon={icon}
              className={classes.tabs} aria-controls={`a-${index}`}
         />

--- a/jsclient/src/features/clusterlist/components/Articles.js
+++ b/jsclient/src/features/clusterlist/components/Articles.js
@@ -27,10 +27,11 @@ const proccessedContentTitle = "proccessed content";
 function Articles({ articles, icons, contents }) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const classes = makeStyles();
+  const hasProcessedContent = !!contents && contents.length > 0;
   const allArticlesAreTyped = articles.reduce(
-      (art, allTyped) => (allTyped && articleTypes.includes(art["article_type"])), true);
+      (allTyped, art) => !!(allTyped && articleTypes.includes(art["article_type"])), true);
   // if no content, and no special type, returning simple article
-  if (articles.length === 1 && (!allArticlesAreTyped || !contents)) {
+  if (articles.length === 1 && !allArticlesAreTyped && !hasProcessedContent) {
     return <Article article={articles[0]} />;
   }
 
@@ -84,7 +85,7 @@ function Articles({ articles, icons, contents }) {
     index += 1;
   }
 
-  if (!!contents && contents.length !== 0) {
+  if (hasProcessedContent) {
     contents.forEach(pushProcessedContent);
   }
   // if all articles are typed, pushing typed content formatter first

--- a/jsclient/src/features/clusterlist/components/Articles.js
+++ b/jsclient/src/features/clusterlist/components/Articles.js
@@ -105,6 +105,7 @@ function Articles({ articles, icons, contents }) {
   return (
     <>
       <Tabs indicatorColor="primary" textColor="primary"
+        variant="scrollable" scrollButtons="auto"
         value={currentIndex}
         onChange={(e, v) => setCurrentIndex(v)}>
         {tabs}

--- a/jsclient/src/features/clusterlist/components/ProcessedContent.js
+++ b/jsclient/src/features/clusterlist/components/ProcessedContent.js
@@ -8,8 +8,12 @@ import makeStyles from "./style";
 
 function ProcessedContent({ content, hidden }) {
   const classes = makeStyles();
-  let head, comments, body;
+  let title, titleDivider, link, comments, linksDivider, body;
   if (content.type === "fetched") {
+    if (content.title) {
+      title = (<Typography variant="h6">{content.title}</Typography>);
+      titleDivider = <Divider />;
+    }
     if (content.comments) {
       comments = (
         <p>
@@ -20,7 +24,7 @@ function ProcessedContent({ content, hidden }) {
         </p>
       );
     }
-    head = (
+    link = (
       <p>
         <span>Link</span>
         <Link color="secondary" target="_blank" href={content.link}>
@@ -29,15 +33,13 @@ function ProcessedContent({ content, hidden }) {
       </p>
     );
     body = (
-      <div className={classes.articleInner}>
-        <Typography
-          dangerouslySetInnerHTML={{__html: content.content}}
-        />
-      </div>
+      <Typography className={classes.articleInner}
+          dangerouslySetInnerHTML={{__html: content.content}} />
     );
+    linksDivider = <Divider />;
   } else if (content.type === "youtube") {
     body = (
-      <div className={classes.videoContainer}>
+      <Typography className={classes.videoContainer}>
         <iframe key="jarr-proccessed-content"
           title="JARR processed Player"
           id="ytplayer"
@@ -45,14 +47,16 @@ function ProcessedContent({ content, hidden }) {
           src={`https://www.youtube-nocookie.com/embed/${content.link}`}
           frameBorder="0"
         />
-      </div>
+      </Typography>
     );
   }
   return (
     <div hidden={hidden} className={classes.article}>
-      {head}
+      {title}
+      {titleDivider}
+      {link}
       {comments}
-      <Divider />
+      {linksDivider}
       {body}
     </div>
   );

--- a/jsclient/src/features/clusterlist/components/TypedContents.js
+++ b/jsclient/src/features/clusterlist/components/TypedContents.js
@@ -21,29 +21,31 @@ export function TypedContents({ type, articles, hidden }) {
                      src={article.link}
                      alt={article.title} title={article.title} />);
     } else if (type === "audio") {
+      if(article.title) {
+        body.push(<Typography variant="h6">{article.title}</Typography>);
+      }
       body.push(<audio controls key={`v-${article.id}`}>
                   <source src={article.link} />
                 </audio>);
     } else if (type === "video") {
+      if(article.title) {
+        body.push(<Typography variant="h6">{article.title}</Typography>);
+      }
       body.push(<video controls key={`a-${article.id}`}>
                   <source src={article.link} />
                 </video>);
     }
   });
-
-  return (
-    <div hidden={hidden} className={classes.article}>
-      <Typography hidden={!!hidden}>
-        {body}
-      </Typography>
-    </div>
-  );
+  return (<Typography hidden={!!hidden} className={classes.article}>
+            {body}
+          </Typography>);
 }
 
 TypedContents.propTypes = {
   type: PropTypes.string.isRequired,
   articles: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.number.isRequired,
+    title: PropTypes.string,
     link: PropTypes.string.isRequired,
     "article_type": PropTypes.string.isRequired})),
   hidden: PropTypes.bool.isRequired,

--- a/jsclient/src/features/clusterlist/components/TypedContents.js
+++ b/jsclient/src/features/clusterlist/components/TypedContents.js
@@ -8,37 +8,51 @@ export const articleTypes = ["image", "audio", "video"];
 
 export function TypedContents({ type, articles, hidden }) {
   const classes = makeStyles();
-  let body = [];
-  let processed = [];
   if (articles.length === 0) { return ; }
-  articles.forEach((article) => {
-    if(processed.includes(article.link)) {
-      return ;
-    }
-    processed.push(article.link);
-    if (type === "image") {
-      body.push(<img key={`i-${article.id}`}
-                     src={article.link}
-                     alt={article.title} title={article.title} />);
-    } else if (type === "audio") {
-      if(article.title) {
-        body.push(<Typography variant="h6">{article.title}</Typography>);
-      }
-      body.push(<audio controls key={`v-${article.id}`}>
-                  <source src={article.link} />
-                </audio>);
-    } else if (type === "video") {
-      if(article.title) {
-        body.push(<Typography variant="h6">{article.title}</Typography>);
-      }
-      body.push(<video controls loop key={`a-${article.id}`}>
-                  <source src={article.link} />
-                </video>);
-    }
-  });
-  return (<Typography hidden={!!hidden} className={classes.article}>
-            {body}
-          </Typography>);
+  let processedUrls = [];
+  return (
+    <div hidden={!!hidden} className={classes.article}>
+      {articles.filter(
+          (article) => {
+            if (processedUrls.includes(article.link)) {
+              return false;
+            }
+            processedUrls.push(article.link);
+            return true;
+          }).map((article) => {
+        let media;
+        if (type === "image") {
+          media = (<img key={`image-${article.id}`}
+                        src={article.link}
+                        alt={article.title} title={article.title} />);
+        } else if (type === "audio") {
+          media = (<audio controls key={`audio-${article.id}`}>
+                     <source src={article.link} />
+                   </audio>);
+          if(article.title) {
+            media = (<>
+                       <Typography variant="h6" key={`title-${article.id}`}>
+                          {article.title}
+                       </Typography>
+                       {media}
+                     </>);
+          }
+        } else if (type === "video") {
+          media = (<video controls loop key={`video-${article.id}`}>
+                     <source src={article.link} />
+                   </video>);
+          if(article.title) {
+            media = (<>
+                       <Typography variant="h6" key={`title-${article.id}`}>
+                          {article.title}
+                       </Typography>
+                       {media}
+                     </>);
+          }
+        }
+        return media;
+      })}
+    </div>);
 }
 
 TypedContents.propTypes = {

--- a/jsclient/src/features/clusterlist/components/TypedContents.js
+++ b/jsclient/src/features/clusterlist/components/TypedContents.js
@@ -17,15 +17,15 @@ export function TypedContents({ type, articles, hidden }) {
     }
     processed.push(article.link);
     if (type === "image") {
-      body.push(<img key={`i-${article.link}`}
+      body.push(<img key={`i-${article.id}`}
                      src={article.link}
                      alt={article.title} title={article.title} />);
     } else if (type === "audio") {
-      body.push(<audio controls key={`v-${article.link}`}>
+      body.push(<audio controls key={`v-${article.id}`}>
                   <source src={article.link} />
                 </audio>);
     } else if (type === "video") {
-      body.push(<video controls key={`a-${article.link}`}>
+      body.push(<video controls key={`a-${article.id}`}>
                   <source src={article.link} />
                 </video>);
     }
@@ -43,6 +43,7 @@ export function TypedContents({ type, articles, hidden }) {
 TypedContents.propTypes = {
   type: PropTypes.string.isRequired,
   articles: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.number.isRequired,
     link: PropTypes.string.isRequired,
     "article_type": PropTypes.string.isRequired})),
   hidden: PropTypes.bool.isRequired,

--- a/jsclient/src/features/clusterlist/components/TypedContents.js
+++ b/jsclient/src/features/clusterlist/components/TypedContents.js
@@ -31,7 +31,7 @@ export function TypedContents({ type, articles, hidden }) {
       if(article.title) {
         body.push(<Typography variant="h6">{article.title}</Typography>);
       }
-      body.push(<video controls key={`a-${article.id}`}>
+      body.push(<video controls loop key={`a-${article.id}`}>
                   <source src={article.link} />
                 </video>);
     }

--- a/jsclient/src/features/clusterlist/components/style.js
+++ b/jsclient/src/features/clusterlist/components/style.js
@@ -7,19 +7,19 @@ export default makeStyles((theme: Theme) =>
       maxWidth: "100%",
     },
     article: {
-      overflowX: "hidden",
-      overflowWrap: "anywhere",
+      "& h6": {
+        padding: "8px 0",
+      },
       "& p": {
-        maxWidth: "100%",
-        width: "auto !important",
         "& span": {
           paddingRight: 30,
           fontStyle: "bold",
         },
-      },
-      "& div": {
-        maxWidth: "100%",
-        width: "auto !important",
+        "& a": {
+          overflowX: "hidden",
+          whiteSpace: "nowrap",
+          maxWidth: "80%",
+        }
       },
       "& img": {
         maxWidth: "100%",

--- a/jsclient/src/features/clusterlist/components/style.js
+++ b/jsclient/src/features/clusterlist/components/style.js
@@ -11,6 +11,7 @@ export default makeStyles((theme: Theme) =>
         padding: "8px 0",
       },
       "& p": {
+        overflowX: "hidden",
         "& span": {
           paddingRight: 30,
           fontStyle: "bold",


### PR DESCRIPTION
* setting scrollable tab for big clusters
* displaying article title in wide screen mode 
* fixing article sorting for cluster displaying : 
  * displaying processed content first (fetched articles, embedded player integration)
  * if all cluster member are typed content (image, video, audio) custom typed display comes first 
  * otherwise the classic, non typed article are displayed, then the typed content, then the typed articles 